### PR TITLE
Reworked the from_ber method to not return nil on invalid data

### DIFF
--- a/grizzly_ber.gemspec
+++ b/grizzly_ber.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'grizzly_ber'
-  s.version     = '1.0.5'
-  s.date        = '2015-06-15'
+  s.version     = '1.0.6'
+  s.date        = '2015-07-29'
   s.summary     = "Fiercest TLV-BER parser"
   s.description = "CODEC for EMV TLV-BER encoded strings."
   s.authors     = ["Ryan Balsdon"]

--- a/lib/grizzly_ber.rb
+++ b/lib/grizzly_ber.rb
@@ -118,8 +118,7 @@ class GrizzlyBer
     raise ArgumentError, "byte_array must be an array of bytes" unless byte_array.is_a? Array and byte_array.all? {|byte| byte.is_a? Integer and byte <= 0xFF}
     while byte_array.size > 0
       element = GrizzlyBerElement.new(byte_array)
-      return nil if element.tag.nil?
-      return nil if element.value.nil?
+      break if element.tag.nil? or element.value.nil?
       @elements << element
     end
     self

--- a/test/test_grizzly_ber.rb
+++ b/test/test_grizzly_ber.rb
@@ -207,7 +207,7 @@ class GrizzlyBerTest < Minitest::Test
 
   def test_add_extra_string
     tlv = GrizzlyBer.new("5A01AA")
-    tlv.from_ber_hex_string("570155")
+    refute_nil tlv.from_ber_hex_string("570155")
     assert_equal 2, tlv.size
     refute_nil tlv["5A"]
     refute_nil tlv["57"]
@@ -237,5 +237,43 @@ class GrizzlyBerTest < Minitest::Test
   def test_invalid_cardholder_name_doesnt_crash
     tlv = GrizzlyBer.new "5F200CE789A9E79086E695B8E5ADB89F0607A0000000041010"
     tlv.to_s
+  end
+
+  def test_pad_between_tags
+    tlv = GrizzlyBer.new("5A01AA570155")
+    refute_nil tlv.from_ber_hex_string("9F1E01AA00009F1D0155")
+    refute_nil tlv.from_ber_hex_string("9F1C01A1FFFF9F1B0151")
+    assert_equal 6, tlv.size
+    refute_nil tlv["5A"]
+    refute_nil tlv["57"]
+    refute_nil tlv["9F1E"]
+    refute_nil tlv["9F1D"]
+    refute_nil tlv["9F1C"]
+    refute_nil tlv["9F1B"]
+    assert_equal [0xAA], tlv["5A"]
+    assert_equal [0x55], tlv["57"]
+    assert_equal [0xAA], tlv["9F1E"]
+    assert_equal [0x55], tlv["9F1D"]
+    assert_equal [0xA1], tlv["9F1C"]
+    assert_equal [0x51], tlv["9F1B"]
+  end
+
+  def test_pad_after_tags
+    tlv = GrizzlyBer.new("5A01AA570155")
+    refute_nil tlv.from_ber_hex_string("9F1E01AA9F1D01550000")
+    refute_nil tlv.from_ber_hex_string("9F1C01A19F1B0151FFFF")
+    assert_equal 6, tlv.size
+    refute_nil tlv["5A"]
+    refute_nil tlv["57"]
+    refute_nil tlv["9F1E"]
+    refute_nil tlv["9F1D"]
+    refute_nil tlv["9F1C"]
+    refute_nil tlv["9F1B"]
+    assert_equal [0xAA], tlv["5A"]
+    assert_equal [0x55], tlv["57"]
+    assert_equal [0xAA], tlv["9F1E"]
+    assert_equal [0x55], tlv["9F1D"]
+    assert_equal [0xA1], tlv["9F1C"]
+    assert_equal [0x51], tlv["9F1B"]
   end
 end


### PR DESCRIPTION
This is so that the output of tlv.from_ber_hex_string can be piped into other functions.
All valid tags up until the first error will be present. 
Zero pads at the end of a TLV array are not considered valid. Only pads in between TLV elements are valid.