### PR TITLE
Asserting on parsing errors

### DIFF
--- a/grizzly_ber.gemspec
+++ b/grizzly_ber.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'grizzly_ber'
-  s.version     = '1.0.7'
+  s.version     = '1.1.0'
   s.date        = '2015-07-29'
   s.summary     = "Fiercest TLV-BER parser"
   s.description = "CODEC for EMV TLV-BER encoded strings."


### PR DESCRIPTION
Review please @davidseal 

This will now assert on parsing errors instead of silently providing data up until the first error.

It also kind of fixes https://github.com/Shopify/grizzly_ber/issues/13 by giving a constructor param to allow it.