### PR TITLE
Fix frozen string literal warning

### DIFF
--- a/grizzly_ber.gemspec
+++ b/grizzly_ber.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'grizzly_ber'
-  s.version     = '1.0.7'
+  s.version     = '1.0.8'
   s.date        = '2015-07-29'
   s.summary     = "Fiercest TLV-BER parser"
   s.description = "CODEC for EMV TLV-BER encoded strings."

--- a/lib/grizzly_ber.rb
+++ b/lib/grizzly_ber.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'grizzly_tag'
 
 class GrizzlyBerElement
@@ -5,7 +7,7 @@ class GrizzlyBerElement
 
   def initialize(byte_array = [])
     raise ArgumentError, "byte_array must be of type Array" unless byte_array.is_a?(Array)
-    @tag = "" # is an uppercase hex string
+    @tag = +"" # is an uppercase hex string
     @value = nil # is a byte array if this is a data element or a GrizzlyBer if it's a sequence element
     decode_value decode_length decode_tag byte_array
   end

--- a/lib/grizzly_tag.rb
+++ b/lib/grizzly_tag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GrizzlyTag
   def self.new_tag(params)
     params[:format] ||= :binary


### PR DESCRIPTION
This is already fixed on the 1.1.x branch, but 1.1.x includes a behavior change from https://github.com/Shopify/grizzly_ber/pull/14

This PR will merge this in a new branch, `1-0-stable` (that branch was created from the `v1.0.7` tag, the latest version in the 1.0.x versions)

This PR also adds a commit to bump the version to 1.0.8

Similar to https://github.com/Shopify/grizzly_ber/commit/c832c0b35283fd161a285911c5a2b966bf1ffb8a