### PR TITLE
Update version to 1.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    grizzly_ber (1.1.1)
+    grizzly_ber (1.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/grizzly_ber.gemspec
+++ b/grizzly_ber.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'grizzly_ber'
-  s.version     = '1.1.1'
+  s.version     = '1.2.0'
   s.date        = '2015-07-29'
   s.summary     = "Fiercest TLV-BER parser"
   s.description = "CODEC for EMV TLV-BER encoded strings."


### PR DESCRIPTION
We are bumping from version `1.1.1` to `1.2.0` which publishes the required Ruby version specified in the gemspec. This way it populates on the rubygems.org UI, which it currently does not.

<img width="998" height="625" alt="required_ruby_version_not_displaying" src="https://github.com/user-attachments/assets/6bd48b22-0b13-4adc-974a-ad9ee50493a8" />
